### PR TITLE
support for tlds containing hyphen and sub-subdomains

### DIFF
--- a/hetznerdnshook.py
+++ b/hetznerdnshook.py
@@ -10,7 +10,7 @@ def get_zone_id(api_token, zone_name):
         _EXITCODE=2
         return False
     for zone in zones_resp['zones']:
-        if zone['name'] == zone_name:
+        if zone_name.endswith(zone['name']):
             return zone['id']
     print("Zone not found")
     _EXITCODE=3
@@ -62,7 +62,7 @@ def get_tld(domain):
 
 def get_sub(domain):
     try:
-        return re.search(r"((\w+\.)*)?\w+\.\w+$", domain.strip()).group(1)[:-1]
+        return re.search(r"(([\w'-]+\.)*)?[\w'-]+\.\w+$", domain.strip()).group(1)[:-1]
     except:
         _EXITCODE=6
         return -1


### PR DESCRIPTION
```get_sub``` should be able to get the subdomain if the domain contains a hyphen (eg ```my-domain.org```) . Regex was updated to support hyphens.
```get_zone_id``` failed if the domain is a sub-subdomain (```subsub.sub.my-domain.org```), so ```endswith``` is used instead of ```==```. There might be a better solution for supporting sub subdomains.